### PR TITLE
added decorator for adding a handler function to the route list

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ from microWebSrv import MicroWebSrv
 
 # ----------------------------------------------------------------------------
 
+@MicroWebSrv.route('/test')
 def _httpHandlerTestGet(httpClient, httpResponse) :
 	content = """\
 	<!DOCTYPE html>
@@ -28,6 +29,7 @@ def _httpHandlerTestGet(httpClient, httpResponse) :
 								  contentCharset = "UTF-8",
 								  content 		 = content )
 
+@MicroWebSrv.route('/test', 'POST')
 def _httpHandlerTestPost(httpClient, httpResponse) :
 	formData  = httpClient.ReadRequestPostedFormData()
 	firstname = formData["firstname"]
@@ -72,12 +74,12 @@ def _closedCallback(webSocket) :
 
 # ----------------------------------------------------------------------------
 
-routeHandlers = [
-	( "/test",	"GET",	_httpHandlerTestGet ),
-	( "/test",	"POST",	_httpHandlerTestPost )
-]
+#routeHandlers = [
+#	( "/test",	"GET",	_httpHandlerTestGet ),
+#	( "/test",	"POST",	_httpHandlerTestPost )
+#]
 
-srv = MicroWebSrv(routeHandlers=routeHandlers)
+srv = MicroWebSrv(webPath='www/')
 srv.MaxWebSocketRecvLen     = 256
 srv.WebSocketThreaded		= False
 srv.AcceptWebSocketCallback = _acceptWebSocketCallback

--- a/microWebSrv.py
+++ b/microWebSrv.py
@@ -65,8 +65,25 @@ class MicroWebSrv :
     _pyhtmlPagesExt = '.pyhtml'
 
     # ============================================================================
+    # ===( Class globals  )=======================================================
+    # ============================================================================
+
+    _docoratedRouteHandlers = []
+
+    # ============================================================================
     # ===( Utils  )===============================================================
     # ============================================================================
+
+    @classmethod
+    def route(cls, url, method='GET'):
+        """ Adds a route handler function to the routing list """
+        def route_decorator(func):
+            item = (url, method, func)
+            cls._docoratedRouteHandlers.append(item)
+            return func
+        return route_decorator
+
+    # ----------------------------------------------------------------------------
 
     def HTMLEscape(s) :
         return ''.join(MicroWebSrv._html_escape_chars.get(c, c) for c in s)
@@ -143,7 +160,10 @@ class MicroWebSrv :
                   port          = 80,
                   bindIP        = '0.0.0.0',
                   webPath       = "/flash/www" ) :
-        self._routeHandlers = routeHandlers
+        
+        self._routeHandlers = self._docoratedRouteHandlers
+        if routeHandlers:
+            self._routeHandlers.append(routeHandlers)
         self._srvAddr       = (bindIP, port)
         self._webPath       = webPath
         self._notFoundUrl   = None


### PR DESCRIPTION
Instead of:
```
def _httpHandlerTestGet(httpClient, httpResponse):
    pass

routeHandlers = [( "/test", "GET", _httpHandlerTestGet)]

MicroWebSrv(routeHandlers=routeHandlers)
```

You can use the decorator before the handler function:
```
@MicroWebSrv.route('/test')
def _httpHandlerTestGet(httpClient, httpResponse):
    pass

MicroWebSrv()
```
Additional you can also use the 'old' way