### PR TITLE
Variable route

### DIFF
--- a/main.py
+++ b/main.py
@@ -56,10 +56,10 @@ def _httpHandlerTestPost(httpClient, httpResponse) :
 								  content 		 = content )
 
 
-@MicroWebSrv.route('/edit/<index>')             # <IP>/edit/123           ->   args.index=123
-@MicroWebSrv.route('/edit/<index>/abc/<foo>')   # <IP>/edit/123/abc/bar   ->   args.index=123  args.foo='bar'
-@MicroWebSrv.route('/edit')                     # <IP>/edit               ->   args=None
-def _httpHandlerEditWithArgs(httpClient, httpResponse, args=None) :
+@MicroWebSrv.route('/edit/<index>')             # <IP>/edit/123           ->   args['index']=123
+@MicroWebSrv.route('/edit/<index>/abc/<foo>')   # <IP>/edit/123/abc/bar   ->   args['index']=123  args['foo']='bar'
+@MicroWebSrv.route('/edit')                     # <IP>/edit               ->   args={}
+def _httpHandlerEditWithArgs(httpClient, httpResponse, args={}) :
 	content = """\
 	<!DOCTYPE html>
 	<html lang=en>
@@ -68,10 +68,20 @@ def _httpHandlerEditWithArgs(httpClient, httpResponse, args=None) :
             <title>TEST EDIT</title>
         </head>
         <body>
-            <h1>EDIT item with {} arguments and index = {}</h1>
+	"""
+	content += "<h1>EDIT item with {} variable arguments</h1>"\
+		.format(len(args))
+	
+	if 'index' in args :
+		content += "<p>index = {}</p>".format(args['index'])
+	
+	if 'foo' in args :
+		content += "<p>foo = {}</p>".format(args['foo'])
+	
+	content += """
         </body>
     </html>
-	""".format(len(args) if args else 'no', args.index if args else 'default')
+	"""
 	httpResponse.WriteResponseOk( headers		 = None,
 								  contentType	 = "text/html",
 								  contentCharset = "UTF-8",

--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ from microWebSrv import MicroWebSrv
 def _httpHandlerTestGet(httpClient, httpResponse) :
 	content = """\
 	<!DOCTYPE html>
-	<html lang=fr>
+	<html lang=en>
         <head>
         	<meta charset="UTF-8" />
             <title>TEST GET</title>
@@ -29,6 +29,7 @@ def _httpHandlerTestGet(httpClient, httpResponse) :
 								  contentCharset = "UTF-8",
 								  content 		 = content )
 
+
 @MicroWebSrv.route('/test', 'POST')
 def _httpHandlerTestPost(httpClient, httpResponse) :
 	formData  = httpClient.ReadRequestPostedFormData()
@@ -36,7 +37,7 @@ def _httpHandlerTestPost(httpClient, httpResponse) :
 	lastname  = formData["lastname"]
 	content   = """\
 	<!DOCTYPE html>
-	<html lang=fr>
+	<html lang=en>
 		<head>
 			<meta charset="UTF-8" />
             <title>TEST POST</title>
@@ -49,6 +50,28 @@ def _httpHandlerTestPost(httpClient, httpResponse) :
     </html>
 	""" % ( MicroWebSrv.HTMLEscape(firstname),
 		    MicroWebSrv.HTMLEscape(lastname) )
+	httpResponse.WriteResponseOk( headers		 = None,
+								  contentType	 = "text/html",
+								  contentCharset = "UTF-8",
+								  content 		 = content )
+
+
+@MicroWebSrv.route('/edit/#')       # <IP>/edit/123       ->   index='123'
+@MicroWebSrv.route('/edit/#/abc')   # <IP>/edit/123/abc   ->   index='123'
+@MicroWebSrv.route('/edit')         # <IP>/edit           ->   index='default'
+def _httpHandlerEditVariable(httpClient, httpResponse, index='default') :
+	content = """\
+	<!DOCTYPE html>
+	<html lang=en>
+        <head>
+        	<meta charset="UTF-8" />
+            <title>TEST EDIT</title>
+        </head>
+        <body>
+            <h1>EDIT item with index '%s'</h1>
+        </body>
+    </html>
+	""" % index
 	httpResponse.WriteResponseOk( headers		 = None,
 								  contentType	 = "text/html",
 								  contentCharset = "UTF-8",

--- a/main.py
+++ b/main.py
@@ -56,10 +56,10 @@ def _httpHandlerTestPost(httpClient, httpResponse) :
 								  content 		 = content )
 
 
-@MicroWebSrv.route('/edit/#')       # <IP>/edit/123       ->   index='123'
-@MicroWebSrv.route('/edit/#/abc')   # <IP>/edit/123/abc   ->   index='123'
-@MicroWebSrv.route('/edit')         # <IP>/edit           ->   index='default'
-def _httpHandlerEditVariable(httpClient, httpResponse, index='default') :
+@MicroWebSrv.route('/edit/<index>')             # <IP>/edit/123           ->   args.index=123
+@MicroWebSrv.route('/edit/<index>/abc/<foo>')   # <IP>/edit/123/abc/bar   ->   args.index=123  args.foo='bar'
+@MicroWebSrv.route('/edit')                     # <IP>/edit               ->   args=None
+def _httpHandlerEditWithArgs(httpClient, httpResponse, args=None) :
 	content = """\
 	<!DOCTYPE html>
 	<html lang=en>
@@ -68,10 +68,10 @@ def _httpHandlerEditVariable(httpClient, httpResponse, index='default') :
             <title>TEST EDIT</title>
         </head>
         <body>
-            <h1>EDIT item with index '%s'</h1>
+            <h1>EDIT item with {} arguments and index = {}</h1>
         </body>
     </html>
-	""" % index
+	""".format(len(args) if args else 'no', args.index if args else 'default')
 	httpResponse.WriteResponseOk( headers		 = None,
 								  contentType	 = "text/html",
 								  contentCharset = "UTF-8",

--- a/microWebSrv.py
+++ b/microWebSrv.py
@@ -8,6 +8,8 @@ from    os          import stat
 from    _thread     import start_new_thread
 import  socket
 import  gc
+import  collections
+import  re
 
 try :
     from microWebTemplate import MicroWebTemplate
@@ -156,14 +158,11 @@ class MicroWebSrv :
     # ============================================================================
 
     def __init__( self,
-                  routeHandlers = None,
+                  routeHandlers = [],
                   port          = 80,
                   bindIP        = '0.0.0.0',
                   webPath       = "/flash/www" ) :
         
-        self._routeHandlers = self._docoratedRouteHandlers
-        if routeHandlers:
-            self._routeHandlers.append(routeHandlers)
         self._srvAddr       = (bindIP, port)
         self._webPath       = webPath
         self._notFoundUrl   = None
@@ -172,6 +171,26 @@ class MicroWebSrv :
         self.MaxWebSocketRecvLen     = 1024
         self.WebSocketThreaded       = True
         self.AcceptWebSocketCallback = None
+
+        routeHandlersCls = collections.namedtuple('routeHandlers', 'route method func routeArgNames routeRegex')
+        self._routeHandlers = []
+        routeHandlers += self._docoratedRouteHandlers
+        for route, method, func in routeHandlers :
+            routeParts = route.split('/')
+            # -> ['', 'users', '<uID>', 'addresses', '<addrID>', 'test', '<anotherID>']
+            routeArgNames = []
+            routeRegex    = ''
+            for s in routeParts :
+                if s.startswith('<') and s.endswith('>') :
+                    routeArgNames.append(s[1:-1])
+                    routeRegex += '/(\\w*)'
+                elif s :
+                    routeRegex += '/' + s
+            routeRegex += '$'
+            # -> '/users/(\w*)/addresses/(\w*)/test/(\w*)$'
+            routeRegex = re.compile(routeRegex)
+
+            self._routeHandlers.append(routeHandlersCls(route, method, func, routeArgNames, routeRegex))
 
     # ============================================================================
     # ===( Server Process )=======================================================
@@ -235,22 +254,28 @@ class MicroWebSrv :
 
     def GetRouteHandler(self, resUrl, method) :
         if self._routeHandlers :
-            resUrl = resUrl.upper()
+            #resUrl = resUrl.upper()
             if resUrl.endswith('/') :
                 resUrl = resUrl[:-1]
             method = method.upper()
-            for route in self._routeHandlers :
-                if len(route) == 3 and route[1].upper() == method :
-                    url = route[0].upper()
-                    if '#' in url:
-                        urlStart, urlEnd = url.split('#', 1)
-                        if resUrl.startswith(urlStart) and resUrl.endswith(urlEnd) :
-                            routeVariable = resUrl[len(urlStart): len(resUrl)-len(urlEnd)]
-                            if '/' not in routeVariable :
-                                return (route[2], routeVariable)
-                    else:
-                        if url == resUrl :
-                            return (route[2], None)
+            for rh in self._routeHandlers :
+                if len(rh) == 5 and rh.method == method :
+                    m = rh.routeRegex.match(resUrl)
+                    if m :   # found matching route?
+                        if rh.routeArgNames :
+                            routeArgValues = []
+                            for i in range(len(rh.routeArgNames)) :
+                                value = m.group(i+1)
+                                try :
+                                    value = int(value)
+                                except :
+                                    pass
+                                routeArgValues.append(value)
+                            routeArgCls = collections.namedtuple('routeArg', rh.routeArgNames)
+                            routeArgs = routeArgCls(*routeArgValues)
+                            return (rh.func, routeArgs)
+                        else :
+                            return (rh.func, None)
         return (None, None)
 
     # ----------------------------------------------------------------------------
@@ -300,10 +325,10 @@ class MicroWebSrv :
                     if self._parseHeader(response) :
                         upg = self._getConnUpgrade()
                         if not upg :
-                            routeHandler, routeVariable = self._microWebSrv.GetRouteHandler(self._resPath, self._method)
+                            routeHandler, routeArgs = self._microWebSrv.GetRouteHandler(self._resPath, self._method)
                             if routeHandler :
-                                if routeVariable is not None:
-                                    routeHandler(self, response, routeVariable)
+                                if routeArgs is not None:
+                                    routeHandler(self, response, routeArgs)
                                 else:
                                     routeHandler(self, response)
                             elif self._method.upper() == "GET" :


### PR DESCRIPTION
_ADAPTED TO NEW IMPLEMENTATION_

Using a '<...>' in the given route like `@MicroWebSrv.route('/edit/<index>')` is interpreted as variable part of the route which is passed as 3rd parameter to the handler function as `args.index`.

With the handler definition:
```python
@MicroWebSrv.route('/edit/<index>')
def _httpHandlerEditWithArgs(httpClient, httpResponse, args) :
```
the following calls will result in:
```
<IP>/edit/123               ->   args['index']=123
<IP>/edit/a                 ->   args['index']='a'
<IP>/edit/Lorem.Ipsum       ->   args['index']='Lorem.Ipsum'
<IP>/edit/Lorem/Ipsum       ->   404
```

This can be used in templated html like (simplyfied):
```html
<h1>Choose an item to edit:</h1>
{{ for item in my_list }}
  <a href="/edit/{{ item.id }}">{{ item.name }}</a>
  <br/>
{{ end }}
```