### PR TITLE
Added template include command

### DIFF
--- a/microWebSrv.py
+++ b/microWebSrv.py
@@ -549,7 +549,7 @@ class MicroWebSrv :
             if 'MicroWebTemplate' in globals() :
                 with open(filepath, 'r') as file :
                     code = file.read()
-                mWebTmpl = MicroWebTemplate(code, escapeStrFunc=MicroWebSrv.HTMLEscape)
+                mWebTmpl = MicroWebTemplate(code, escapeStrFunc=MicroWebSrv.HTMLEscape, filepath=filepath)
                 try :
                     return self.WriteResponseOk(headers, "text/html", "UTF-8", mWebTmpl.Execute())
                 except Exception as ex :

--- a/microWebTemplate.py
+++ b/microWebTemplate.py
@@ -22,14 +22,16 @@ class MicroWebTemplate :
 	INSTRUCTION_ELSE		= 'else'
 	INSTRUCTION_FOR			= 'for'
 	INSTRUCTION_END			= 'end'
+	INSTRUCTION_INCLUDE		= 'include'
 
     # ============================================================================
     # ===( Constructor )==========================================================
     # ============================================================================
 
-	def __init__(self, code, escapeStrFunc=None) :
+	def __init__(self, code, escapeStrFunc=None, filepath='') :
 		self._code   		= code
 		self._escapeStrFunc	= escapeStrFunc
+		self._filepath		= filepath
 		self._pos    		= 0
 		self._endPos 		= len(code)-1
 		self._line   		= 1
@@ -44,6 +46,7 @@ class MicroWebTemplate :
 			MicroWebTemplate.INSTRUCTION_ELSE 	: self._processInstructionELSE,
 			MicroWebTemplate.INSTRUCTION_FOR 	: self._processInstructionFOR,
 			MicroWebTemplate.INSTRUCTION_END	: self._processInstructionEND,
+			MicroWebTemplate.INSTRUCTION_INCLUDE: self._processInstructionINCLUDE,
 		}
 
     # ============================================================================
@@ -85,7 +88,7 @@ class MicroWebTemplate :
 		while self._pos <= self._endPos :
 			c = self._code[self._pos]
 			if c == MicroWebTemplate.TOKEN_OPEN[0] and \
-			   self._code[ self._pos : self._pos + MicroWebTemplate.TOKEN_OPEN_LEN ] == MicroWebTemplate.TOKEN_OPEN :
+			    self._code[ self._pos : self._pos + MicroWebTemplate.TOKEN_OPEN_LEN ] == MicroWebTemplate.TOKEN_OPEN :
 				self._pos    += MicroWebTemplate.TOKEN_OPEN_LEN
 				tokenContent  = ''
 				x 			  = self._pos
@@ -297,6 +300,21 @@ class MicroWebTemplate :
 			raise Exception( 'Instruction "%s" is invalid (line %s)'
 							 % (MicroWebTemplate.INSTRUCTION_END, self._line) )
 		return MicroWebTemplate.INSTRUCTION_END
+
+	# ----------------------------------------------------------------------------
+
+	def _processInstructionINCLUDE(self, instructionBody, execute) :
+		if not instructionBody :
+			raise Exception( '"%s" alone is an incomplete syntax (line %s)' % (MicroWebTemplate.INSTRUCTION_INCLUDE, self._line) )
+		filename = instructionBody.replace('"','').replace("'",'').strip()
+		idx = self._filepath.rindex('/')
+		if idx >= 0 :
+			filename = self._filepath[:idx+1] + filename
+		with open(filename, 'r') as file :
+			includeCode = file.read()
+
+			self._code = self._code[:self._pos] + includeCode + self._code[self._pos:]
+			self._endPos += len(includeCode)
 
     # ============================================================================
     # ============================================================================


### PR DESCRIPTION
In most web pages parts like header, navigation bar and scripts are repeated in all html files. Wirh the command `{{ include <filename> }}` you can include/insert the content of the given file at the position of the command. So, the repeated content must only present once in the includes file. 

The include file is opened in the same dir as the pyhtml file. The file can also content {{}}-commands.

A pyhtml file can look like:
```html
<html>
	<head>
		{{ include head.thtml }}
	</head>
	<body>
		{{ include navbar.thtml }}
		
		<h1>Unique content of this html page</h1>

		{{ include script.thtml }}
	</body>
</html>

```
And the corresponding 'head.thtml' can be:
```html
<meta charset="UTF-8" />
<title>{{ title }}</title>
<link rel="stylesheet" href="style.css" />
```
Note: the file extention 'thtml' is just a suggestion