### PR TITLE
Help browsers to cache static content

### DIFF
--- a/microWebSrv.py
+++ b/microWebSrv.py
@@ -184,9 +184,10 @@ class MicroWebSrv :
         self._notFoundUrl   = None
         self._started       = False
 
-        self.MaxWebSocketRecvLen     = 1024
-        self.WebSocketThreaded       = True
-        self.AcceptWebSocketCallback = None
+        self.MaxWebSocketRecvLen        = 1024
+        self.WebSocketThreaded          = True
+        self.AcceptWebSocketCallback    = None
+        self.LetCacheStaticContentLevel = 2
 
         self._routeHandlers = []
         routeHandlers += self._docoratedRouteHandlers
@@ -357,13 +358,15 @@ class MicroWebSrv :
                                         response.WriteResponsePyHTMLFile(filepath)
                                     else :
                                         contentType = self._microWebSrv.GetMimeTypeFromFilename(filepath)
-                                        if contentType :
-                                            if 'if-modified-since' in self._headers:
+                                        if self._microWebSrv.LetCacheStaticContentLevel > 0 and contentType :
+                                            if self._microWebSrv.LetCacheStaticContentLevel > 1 and 'if-modified-since' in self._headers :
                                                 response.WriteResponseNotModified()
                                             else:
                                                 header = {'Last-Modified':'Fri, 1 Jan 2018 23:42:00 GMT', \
                                                           'Cache-Control':'max-age=315360000'}
                                                 response.WriteResponseFile(filepath, contentType, header)
+                                        elif contentType :
+                                            response.WriteResponseFile(filepath, contentType, header)
                                         else :
                                             response.WriteResponseForbidden()
                                 else :

--- a/microWebSrv.py
+++ b/microWebSrv.py
@@ -358,7 +358,12 @@ class MicroWebSrv :
                                     else :
                                         contentType = self._microWebSrv.GetMimeTypeFromFilename(filepath)
                                         if contentType :
-                                            response.WriteResponseFile(filepath, contentType)
+                                            if 'if-modified-since' in self._headers:
+                                                response.WriteResponseNotModified()
+                                            else:
+                                                header = {'Last-Modified':'Fri, 1 Jan 2018 23:42:00 GMT', \
+                                                          'Cache-Control':'max-age=315360000'}
+                                                response.WriteResponseFile(filepath, contentType, header)
                                         else :
                                             response.WriteResponseForbidden()
                                 else :
@@ -711,6 +716,11 @@ class MicroWebSrv :
                                        "application/json",
                                        "UTF-8",
                                        dumps(obj if obj else { }) )
+
+        # ------------------------------------------------------------------------
+
+        def WriteResponseNotModified(self) :
+            return self.WriteResponseError(304)
 
         # ------------------------------------------------------------------------
 


### PR DESCRIPTION
Till now all static content (CSS, PNG, JS,...) is loaded from IoT-device on each page load.
With additional headers 'Last-Modified' the static content is only loaded at the first time (and after 10 years).
On refresh in browser (F5) a request is send with header 'Is-Modified-Since' and the IoT-device can answer with 304 (Not modified) to prevent sending all again.
This improves loading time of pages dramatically!
PyHTML-files are not affected/cached!

Note: Assuming the static files are really static and a new version gets a new name...

Tested with FireFox, Edge, Chrome (on Windows)