### PR TITLE
Use unquote_plus() to get correct request arguments

### DIFF
--- a/microWebSrv.py
+++ b/microWebSrv.py
@@ -519,8 +519,8 @@ class MicroWebSrv :
                 for s in elements :
                     param = s.split('=', 1)
                     if len(param) > 0 :
-                        value = MicroWebSrv._unquote(param[1]) if len(param) > 1 else ''
-                        res[MicroWebSrv._unquote(param[0])] = value
+                        value = MicroWebSrv._unquote_plus(param[1]) if len(param) > 1 else ''
+                        res[MicroWebSrv._unquote_plus(param[0])] = value
             return res
 
         # ------------------------------------------------------------------------

--- a/microWebSrv.py
+++ b/microWebSrv.py
@@ -405,8 +405,8 @@ class MicroWebSrv :
                             for s in elements :
                                 param = s.split('=', 1)
                                 if len(param) > 0 :
-                                    value = MicroWebSrv._unquote(param[1]) if len(param) > 1 else ''
-                                    self._queryParams[MicroWebSrv._unquote(param[0])] = value
+                                    value = MicroWebSrv._unquote_plus(param[1]) if len(param) > 1 else ''
+                                    self._queryParams[MicroWebSrv._unquote_plus(param[0])] = value
                     return True
             except :
                 pass


### PR DESCRIPTION
On typing "a b" in a form `<input>` the argument arrives at handler with "a+b"
The '+' is a symbol for space while transport and should be replaced on reading header lines.

If you type in the form element:

`[a b]`

you get with actual version a HTTP-GET or HTTP-POST:

`"<addr>/?k=a+b"`

you get a dict with:

`{'k': 'a+b'}`

With this change you get a correct dict with:

`{'k': 'a b'}`