### PR TITLE
Fixed unquote in GET and POST requests for alien characters

### DIFF
--- a/microWebSrv.py
+++ b/microWebSrv.py
@@ -136,22 +136,43 @@ class MicroWebSrv :
 
     # ----------------------------------------------------------------------------
 
-    @staticmethod
-    def _unquote(s) :
-        r = s.split('%')
-        for i in range(1, len(r)) :
-            s = r[i]
-            try :
-                r[i] = chr(int(s[:2], 16)) + s[2:]
-            except :
-                r[i] = '%' + s
-        return ''.join(r)
+    #@staticmethod
+    #def _unquote(s) :
+    #    r = s.split('%')
+    #    for i in range(1, len(r)) :
+    #        s = r[i]
+    #        try :
+    #            r[i] = chr(int(s[:2], 16)) + s[2:]
+    #        except :
+    #            r[i] = '%' + s
+    #    return ''.join(r)
 
-    # ----------------------------------------------------------------------------
+    # ------------------------------------------------------------------------------
+
+    #@staticmethod
+    #def _unquote_plus(s) :
+    #    return MicroWebSrv._unquote(s.replace('+', ' '))
+
+    # ------------------------------------------------------------------------------
 
     @staticmethod
-    def _unquote_plus(s) :
-        return MicroWebSrv._unquote(s.replace('+', ' '))
+    def _unquote_decode(data:str) :
+        i = 0
+        ret = bytearray()
+        while i<len(data):
+            c = ord(data[i])
+            if c == 0x25:   # '%'
+                try:
+                    c = int(data[i+1:i+3], 16)
+                    i += 2   #skip next 2 bytes
+                except:
+                    pass
+            elif c == 0x2B:   # '+'
+                c = 0x20   # ' '
+            ret.append(c)
+            i += 1
+
+        return ret.decode('utf-8')
 
     # ----------------------------------------------------------------------------
 
@@ -406,15 +427,15 @@ class MicroWebSrv :
                     self._httpVer = elements[2].upper()
                     elements      = self._path.split('?', 1)
                     if len(elements) > 0 :
-                        self._resPath = MicroWebSrv._unquote_plus(elements[0])
+                        self._resPath = MicroWebSrv._unquote_decode(elements[0])
                         if len(elements) > 1 :
                             self._queryString = elements[1]
                             elements = self._queryString.split('&')
                             for s in elements :
                                 param = s.split('=', 1)
                                 if len(param) > 0 :
-                                    value = MicroWebSrv._unquote_plus(param[1]) if len(param) > 1 else ''
-                                    self._queryParams[MicroWebSrv._unquote_plus(param[0])] = value
+                                    value = MicroWebSrv._unquote_decode(param[1]) if len(param) > 1 else ''
+                                    self._queryParams[MicroWebSrv._unquote_decode(param[0])] = value
                     return True
             except :
                 pass
@@ -527,8 +548,8 @@ class MicroWebSrv :
                 for s in elements :
                     param = s.split('=', 1)
                     if len(param) > 0 :
-                        value = MicroWebSrv._unquote_plus(param[1]) if len(param) > 1 else ''
-                        res[MicroWebSrv._unquote_plus(param[0])] = value
+                        value = MicroWebSrv._unquote_decode(param[1]) if len(param) > 1 else ''
+                        res[MicroWebSrv._unquote_decode(param[0])] = value
             return res
 
         # ------------------------------------------------------------------------


### PR DESCRIPTION
Fixed unquote in GET and POST requests for German umlauts 'äöüÄÖÜ' and other alien characters.

If characters like  'äöüÄÖÜ' are typed in a form input the browser converts FIRST to utf-8 and SECOND escapes the sequence.

At the server the string has to be unquoted (%xx -> X) first and than convertid from utf-8 to unicode