### PR TITLE
Fixed issue for Pycom devices where decode("UTF-8") is unavailable

### DIFF
--- a/microWebSrv.py
+++ b/microWebSrv.py
@@ -172,7 +172,7 @@ class MicroWebSrv :
             ret.append(c)
             i += 1
 
-        return ret.decode('utf-8')
+        return str(ret, "utf-8")
 
     # ----------------------------------------------------------------------------
 


### PR DESCRIPTION
The decode command in the _unquote_decode function is not working on WiPy/LoPy devices. 
Those devices will directly close the socket without any error (however no response will be send). I updated the function to use the str method instead. 