### PR TITLE
Added support for serving pre-compressed static files

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,16 @@ def _httpHandlerTestPost(httpClient, httpResponse) :
 | default.html |
 | default.htm |
 
+### Pre-compressed static files :
+
+Static files can be pre-compressed to save flash space and speed up network transfers. Ex. `index.html.gz` or `main.js.gz`. The following encodings are supported :
+
+| File extension | Encoding |
+| - | - |
+| .gz   | gzip |
+| .br   | br |
+
+
 ### Using optional module *microWebSocket* to connect WebSockets :
 
 - File `"microWebSocket.py"` must be present to activate WebSockets support


### PR DESCRIPTION
If the request has the `Accept-Encoding` header, will look for files in webPath that are pre-compressed with the specified encoding(s) before falling back to the file without any compression. Sets the `Content-Encoding` header in the response appropriately.

For example, a request for `/main.js`  with the `Accept-Encoding` header set to `gzip, br` will look for  files in this order: `main.js.gz`, `main.js.br`, then `main.js`, No compression is done on the fly. `main.js.gz` should already be compressed with gzip and MicroWebSrv trusts this: it responds with the file as-is, setting the `Content-Encoding` header so that browsers will properly decode.

I'm using this to put only pre-compressed static files (HTML, CSS, Javascript) on my ESP32 to save a considerable amount of space. Also helps with performance as less data is transferred.