### PR TITLE
MicroWebSrv.py: don't create socket with parameters

### DIFF
--- a/microWebSrv.py
+++ b/microWebSrv.py
@@ -214,9 +214,7 @@ class MicroWebSrv :
 
     def Start(self, threaded=False) :
         if not self._started :
-            self._server = socket.socket( socket.AF_INET,
-                                          socket.SOCK_STREAM,
-                                          socket.IPPROTO_TCP )
+            self._server = socket.socket()
             self._server.setsockopt( socket.SOL_SOCKET,
                                      socket.SO_REUSEADDR,
                                      1 )


### PR DESCRIPTION
instead default init it with no parameters. This makes it more cross-platform compatible
since not all uPy platforms have for example IPPROTO_TCP defined (e.g. the pyboard D serie)